### PR TITLE
Some amendmends

### DIFF
--- a/PaymentFlows/SamsungPay/SamsungPayInit.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayInit.pml
@@ -32,7 +32,7 @@ CI->SPS: send token
 SPS->SPA: send token
 SPA->SPA: store card token into trust zone \nof Knox Sandbox\n (can be active or inactive)
 
-opt auth user (e.g. via OTP)/ activate token
+opt auth user (e.g. via OTP)
 CI->CI: generate activation code
 CI->B: activ code
 B->User: send token activation code
@@ -40,17 +40,12 @@ User->SPA: input code
 SPA->SPS:
 SPS->CI:
 CI->CI: validate activation code
+end
+
 CI->CI: activate token
 CI->SPS: notify token status change
 SPS->SPA: notify token status change
 
 end
-
-end
-
-
-
-
-
 
 @enduml

--- a/PaymentFlows/SamsungPay/SamsungPayInit.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayInit.pml
@@ -1,11 +1,12 @@
 @startuml
 Autonumber
 
+
 participant User
 participant "SamsungPay App" as SPA
 participant "SamsungPay Server" as SPS
-participant "Card Issuer" as CI
-participant Bank as B
+participant "Token Service Provider" as CI
+participant Card Issuer (Bank) as B
 
 title SamsungPay Initialization Process (unofficial)
 
@@ -13,21 +14,43 @@ opt User Registration
 User<->SPA: launch SamsungPay App
 SPA<->SPS: login with SamsungPay Account
 end
-opt Adding Credit Card
+opt Adding Card
 User<->SPA: launch SamsungPay App
 opt OCR read via Camera
 SPA->SPA: OCR read credit card via Camera
 end
-SPA->SPA: key-in Credit Card Info
-SPA->SPA: confirm card info
+SPA->SPA: key-in/confirm Card Info
 SPA->SPA: set user's fingerprint
 SPA->SPS: send credit card info as encrypted
 SPS->SPS: decrypt card info
 SPS->CI: send credit card info as re-encrypted
-SPA<->CI: get agreement\nauthenticate user\nretrieve user signature
-CI->SPS: send token auth code
-SPS->SPS: store token auth code
-SPS->SPA: send card token
-SPA->SPA: store card token into trust zone \nof Knox Sandbox
+
+CI<->B: Tokenization Auth Request
+
+note over SPA,SPS,B
+get agreement,
+authenticate user,
+end note
+
+CI->CI: generate token
+CI->SPS: send token
+SPS->SPA: send token
+SPA->SPA: store card token into trust zone \nof Knox Sandbox\n (can be active or inactive)
+
+opt activate token
+CI->CI: generate activation code
+CI->B: activ code
+B->User: send token activation code
+User->SPA: input code
+SPA->SPS:
+SPS->CI:
+CI->CI: validate activation code
+CI->CI: activate token
+CI->SPS: notify token status change
+SPS->SPA: notify token status change
+
 end
+
+end
+
 @enduml

--- a/PaymentFlows/SamsungPay/SamsungPayInit.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayInit.pml
@@ -1,12 +1,11 @@
 @startuml
 Autonumber
 
-
 participant User
 participant "SamsungPay App" as SPA
 participant "SamsungPay Server" as SPS
 participant "Token Service Provider" as CI
-participant Card Issuer (Bank) as B
+participant "Card Issuer (Bank)" as B
 
 title SamsungPay Initialization Process (unofficial)
 
@@ -27,17 +26,13 @@ SPS->CI: send credit card info as re-encrypted
 
 CI<->B: Tokenization Auth Request
 
-note over SPA,SPS,B
-get agreement,
-authenticate user,
-end note
 
 CI->CI: generate token
 CI->SPS: send token
 SPS->SPA: send token
 SPA->SPA: store card token into trust zone \nof Knox Sandbox\n (can be active or inactive)
 
-opt activate token
+opt auth user (e.g. via OTP)/ activate token
 CI->CI: generate activation code
 CI->B: activ code
 B->User: send token activation code
@@ -52,5 +47,10 @@ SPS->SPA: notify token status change
 end
 
 end
+
+
+
+
+
 
 @enduml

--- a/PaymentFlows/SamsungPay/SamsungPayUse.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayUse.pml
@@ -1,4 +1,5 @@
 @startuml
+
 title Using SamsungPay (unofficial)
 
 participant User as U
@@ -21,4 +22,5 @@ opt
 U->S: sign on receipt
 end
 S->U: deliver goods
+
 @enduml

--- a/PaymentFlows/SamsungPay/SamsungPayUse.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayUse.pml
@@ -13,7 +13,7 @@ S->U: show bill
 U->SPA: launch SamsungPay App
 SPA->SPA: select cardtype
 SPA->SPA: user authentication \nwith fingerprint
-SPA->SPA: generate One Time Token ("Cryptogram") \n(can be either with static Token \n(and time-based seed in case of MST),\n or with dynamic token)
+SPA->SPA: generate One Time Token ("Cryptogram") \n(either with static or dynamic Token, \nand time-based seed)
 SPA->S: send OTT via MST or NFC
 SPA<->SPS: store payment history
 S<->CI: get card approval with OTT

--- a/PaymentFlows/SamsungPay/SamsungPayUse.pml
+++ b/PaymentFlows/SamsungPay/SamsungPayUse.pml
@@ -12,11 +12,13 @@ S->U: show bill
 U->SPA: launch SamsungPay App
 SPA->SPA: select cardtype
 SPA->SPA: user authentication \nwith fingerprint
-SPA->SPA: generate One Time Token\nwith static Token and time based seed
+SPA->SPA: generate One Time Token ("Cryptogram") \n(can be either with static Token \n(and time-based seed in case of MST),\n or with dynamic token)
 SPA->S: send OTT via MST or NFC
 SPA<->SPS: store payment history
 S<->CI: get card approval with OTT
 S->U: show payment result
+opt
 U->S: sign on receipt
+end
 S->U: deliver goods
 @enduml


### PR DESCRIPTION
Init flow:
- split two roles of card issuer (usually, a bank) and TSP (can be either card schemes or bank)
- token is created (and sent to device) before (optional) user authentication
- after user auth, token is activated

Use flow:
- change transaction "token" to "cryptogram"
