### PR TITLE
Add Web Payments Core Messages spec to proposals.

### DIFF
--- a/proposals/core-messages/frames/PaymentRequest-frame.jsonld
+++ b/proposals/core-messages/frames/PaymentRequest-frame.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": "https://example.org/contexts/web-payments/v1",
+  "type": "PaymentRequest"
+}

--- a/proposals/core-messages/frames/PaymentResponse-frame.jsonld
+++ b/proposals/core-messages/frames/PaymentResponse-frame.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": "https://example.org/contexts/web-payments/v1",
+  "type": "PaymentResponse"
+}

--- a/proposals/core-messages/index.html
+++ b/proposals/core-messages/index.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Web Payments Core Messages 1.0</title>
+    <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+    <!--
+      === NOTA BENE ===
+      For the three scripts below, if your spec resides on dev.w3 you can check them
+      out in the same tree and use relative links so that they'll work offline,
+     -->
+    <link rel="stylesheet" href="spec.css">
+    <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+    <script src='utils.js' async class='remove'></script>
+    <script type="text/javascript" class="remove">
+var respecConfig = {
+    // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+    specStatus:           "ED",
+
+    // the specification's short name, as in http://www.w3.org/TR/short-name/
+    shortName:            "web-payments-core-messages",
+
+    // if you wish the publication date to be other than today, set this
+    // publishDate:  "2009-08-06",
+
+    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+    // and its maturity status
+    // previousPublishDate:  "1977-03-15",
+    // previousMaturity:  "WD",
+
+    // if there a publicly available Editor's Draft, this is the link
+    edDraftURI:           "https://w3c.github.io/webpayments/proposals/core-messages/",
+
+    // if this is a LCWD, uncomment and set the end of its review period
+    // lcEnd: "2009-08-05",
+
+    // editors, add as many as you like
+    // only "name" is required
+    editors: [
+      { name: "Manu Sporny", url: "https://manu.sporny.org/",
+        company: "Digital Bazaar, Inc.", companyURL: "http://digitalbazaar.com/" },
+    ],
+
+    // authors, add as many as you like.
+    // This is optional, uncomment if you have authors as well as editors.
+    // only "name" is required. Same format as editors.
+
+    authors: [
+      { name: "Manu Sporny", url: "https://manu.sporny.org/",
+        company: "Digital Bazaar, Inc.", companyURL: "http://digitalbazaar.com/" },
+      { name: "Dave Longley", url: "https://github.com/dlongley",
+        company: "Digital Bazaar, Inc.", companyURL: "http://digitalbazaar.com/" },
+    ],
+
+    // extend the bibliography entries
+    //localBiblio: {},
+
+    // name of the WG
+    wg:           "Web Payments Working Group",
+
+    // URI of the public WG page
+    wgURI:        "https://www.w3.org/Payments/WG/",
+
+    // name (with the @w3c.org) of the public mailing to which comments are due
+    wgPublicList: "public-payments-wg",
+
+    // URI of the patent status for this WG, for Rec-track documents
+    // !!!! IMPORTANT !!!!
+    // This is important for Rec-track documents, do not copy a patent URI from a random
+    // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+    // Team Contact.
+    wgPatentURI:  "",
+    maxTocLevel: 4,
+    preProcess: [ ] /*,
+    alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
+    */
+
+};
+    </script>
+</head>
+
+<body>
+<section id="abstract">
+  <p>
+This document specifies the core Web Payments messages that are used to
+initiate and acknowledge a payment request. The messages are typically passed
+between the software ecosystem that inititates, executes, and finalizes
+Web Payments.
+  </p>
+</section>
+
+<section id="sotd">
+
+  <p>The most effective way to report issues and request features is to
+  engage the working group via the Github
+  <a href="https://github.com/w3c/webpayments/issues">issue tracker</a>
+  for the Working Group. Submitting issues as well as pull requests for
+  changes to the specification are encouraged.</p>
+
+</section>
+
+<section class="informative">
+  <h1>Introduction</h1>
+
+  <p>
+When requesting and fulfilling a payment on the Web, a number of messages
+need to be passed between various parties to execute the movement of funds.
+This specification details those core messages and provides instructions on
+how to interpret those messages in a variety of operating environments.
+  </p>
+
+  <section class="informative">
+    <h2>How to Read this Document</h2>
+
+    <p>This document is detailed specification for a set of core messages
+    related to initiating, executing, and finalizing payments on the Web.
+    The document is primarily intended for the following audiences:</p>
+
+    <ul>
+      <li>Software developers who want to understand the design decisions and
+        structure of the core messages.</li>
+      <li>Software developers who want to implement Web Payments systems.</li>
+    </ul>
+  </section>
+  <section class="normative">
+    <h3>Terminology</h3>
+
+  <p class="issue">
+The terminology in this specification's terminology and messages need to be
+updated to match the
+<a href="https://github.com/w3c/webpayments/wiki/A-Payments-Initiation-Architecture-for-the-Web">Payments Architecture document</a>.
+  </p>
+
+    <div data-include="//w3c.github.io/webpayments-ig/latest/common/terms.html"
+      data-oninclude="restrictReferences">
+    </div>
+
+  </section>
+
+</section>
+
+<section>
+  <h2>The Data Model</h2>
+
+  <p class="issue">
+The data model used for the messages in this specification is intended to be
+easily readable and understood by non-technologists. Therefore, it is neither
+rigorous nor formal. Some of the more classicly trained software designers
+may find this disconcerting as types and ranges are not strictly locked down
+at the data model layer. Others will find the need for an abstract data model
+unnecessary, preferring to express the messages in a more concrete syntax.
+Some may want to use UML, others may want RDF, and others may prefer JSON's
+data model. In short, the way the data model is used and expressed in this
+document is up for discussion. The only requirement is that we use something
+that is easily understood by most readers and that's flexible enough to work
+with a variety of programming environments while empowering developers to
+use validation tooling (like JSON Schema) if the facility is available to them.
+  </p>
+
+  <p>
+When designing software systems, the data model used to express
+the components of the system is important. Data models tend to vary in their
+formalism. Some data models are more abstract where data values are not typed
+and only vaguely defined as to what their allowable values may be.
+Other data models are more concrete, with strongly defined value types and
+ranges.
+  </p>
+
+  <p>
+The data model used to document the messages in this specification tends
+toward being more abstract. This is done to aid readability and ensure that
+the data model can be applied in a variety of programming environments. There
+is also a mechanism that we use in this specification that enables more
+formalism when it comes to data types and ranges. This is done to ensure that
+programmers can re-use specific data validation tooling if it is available to
+them.
+  </p>
+
+  <p>
+In an attempt to make the description of this approach easier to understand,
+note the following simple example of a <code>HelloWorld</code>
+message definition:
+  </p>
+
+<h5 style="font-size: 1.2em">HelloWorld</h5>
+
+  <p>
+A message that is used to greet the world.
+  </p>
+
+      <dl>
+        <dt><code>title</code></dt>
+        <dd>
+A short human-readable title for the message.
+        </dd>
+        <dt><code>message</code></dt>
+        <dd>
+The message text itself.
+        </dd>
+      </dl>
+
+  <p>
+Note that there are no formal data value constraints expressed in the message
+definition in the data model. Even though the data model is fairly abstract,
+constraints can still be placed on the values in each concrete syntax (e.g.
+JSON Schema in most JSON environments). These constraints can be found in the
+sections titled
+<a href="#expressing-messages-as-webidl">Expressing Messages as WebIDL</a>,
+<a href="#expressing-messages-as-json">Expressing Messages as JSON</a>, and
+<a href="#expressing-messages-as-json-ld">Expressing Messages as JSON-LD</a>.
+  </p>
+
+  <p>
+For example, if a developer wanted to express the <code>HelloWorld</code>
+message definition above in JSON, the following JSON Schema could be used to
+validate such a message:
+  </p>
+
+  <pre class="highlight">
+{
+  "title": "HelloWorld Message JSON Schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "required": ["title", "message"]
+}
+  </pre>
+
+</section>
+
+<section>
+  <h2>Core Message Components</h2>
+
+    <section>
+      <h3><dfn>FinancialAmount</dfn></h3>
+      <p>
+A <a><code>FinancialAmount</code></a> is used to express a scalar financial
+value.
+      </p>
+      <dl>
+        <dt><code><dfn>currency</dfn></code></dt>
+        <dd>
+<code>currency</code> is a string containing a three-character alphaneumeric
+code for the currency as defined by [[!ISO4217]] or a URL for a currency
+identifier. For example, <code>"USD"</code> for US Dollars or
+<code>"https://example.com/currencies/experimental-XYZ"</code> for a new
+experimental currency.
+        </dd>
+        <dt><code><dfn>amount</dfn></code></dt>
+        <dd>
+A string containing the decimal monetary value. The string MUST use a single
+U+002E FULL STOP character as the decimal separator. The string MUST begin
+with a single U+002D HYPHEN-MINUS character if the value is negative. All
+other characters must be characters in the range U+0030 DIGIT ZERO (0) to
+U+0039 DIGIT NINE (9).
+<div class="note">
+The string should match the regular expression
+<code>^-?[0-9]+(\.[0-9]+)?$</code>.
+</div>
+        </dd>
+      </dl>
+
+      <p>The following example shows how to represent $55.00 US Dollars.</p>
+      <pre class="example highlight" title="$55 US Dollars expressed as JSON">
+{
+  "amount": "55.00",
+  "currency": "USD"
+}
+      </pre>
+    </section>
+
+    <section>
+      <h3><dfn>AcceptablePaymentMethod</dfn></h3>
+
+      <p>
+An <a><code>AcceptablePaymentMethod</code></a> expresses the terms under
+which a payment may be fulfilled.
+      </p>
+      <dl>
+        <dt><code>paymentMethod</code></dt>
+        <dd>
+One or more payment method identifiers (as defined in
+an associated payment method specification). For example,
+<code>"VisaLegacy"</code> or
+<code>"https://newnetwork.example.com/methods/SuperCard"</code>
+
+        </dd>
+        <dt><code>paymentAmount</code></dt>
+        <dd>
+The <a>FinancialAmount</a> requested by the <a>payee</a>. The value may also be
+a set of <a>FinancialAmount</a>s that express the desired amount in
+different currencies.
+        </dd>
+      </dl>
+
+      <pre class="example highlight"
+        title="Payment for $4.35 USD may be fulfilled using non-tokenized Visa and Mastercard expressed as JSON">
+{
+  "paymentMethod": ["VisaLegacy", "MasterCardLegacy"],
+  "paymentAmount": {
+    "amount": "4.35",
+    "currency": "USD"
+}
+      </pre>
+
+    </section>
+  </section>
+
+<section>
+  <h2>Core Messages</h2>
+
+    <section>
+      <h3><dfn>PaymentRequest</dfn></h3>
+
+      <p>
+A <a><code>PaymentRequest</code></a> expresses a payment that is requested
+by a <a>payee</a>.
+      </p>
+      <dl>
+        <dt><code>type</code></dt>
+        <dd>
+A set of one or more type identifiers associated with the object, typically
+set to <code>"PaymentRequest"</code>.
+
+<div class="issue">The set of available types MAY be extended
+in the future to, for example, add things like
+<code>"SubscriptionRequest"</code> to identify payment requests that may
+have some recurring quality to them.
+</div>
+        </dd>
+        <dt><code>description</code></dt>
+        <dd>
+A human-readable description of the reason the payment request was initiated.
+This text MAY be displayed to the <a>payer</a> in a payment interface.
+For example, <code>"Payment for widgets from Acme Anvil Emporium"</code>.
+        </dd>
+        <dt><code>acceptablePayment</code></dt>
+        <dd>
+One or more <a>AcceptablePaymentMethod</a>s that the <a>payee</a> will
+accept as payment.
+        </dd>
+      </dl>
+      <pre class="example highlight"
+        title="An example of a payment request expressed in JSON">
+{
+  "type": "PaymentRequest",
+  "description": "Payment to ExampleMerch for widgets",
+  "acceptablePayment": {
+    "paymentMethod": "VisaLegacy",
+    "paymentAmount": {
+      "amount": "4.35",
+      "currency": "USD"
+    }
+  }
+};
+      </pre>
+    </section>
+
+    <section>
+      <h3><dfn>PaymentResponse</dfn></h3>
+
+      <p>
+A <a><code>PaymentResponse</code></a> expresses the result of processing
+a payment request.
+      </p>
+      <dl>
+        <dt><code>type</code></dt>
+        <dd>
+An type identifier associated with the object, typically set to
+<code>"PaymentResponse"</code>.
+
+<div class="issue">
+The set of available types MAY be extended in the future to add things
+like <code>Receipt</code> to identify acknowledgements that contain
+receipt information.
+</div>
+        </dd>
+        <dt><code>description</code></dt>
+        <dd>
+Human readable text that will be used to identify what the payment was for.
+This text MAY be displayed to the <a>payer</a>. For example,
+<code>"Payment to ExampleMerch for widgets"</code>.
+        </dd>
+        <dt><code>payment</code></dt>
+        <dd>
+Information such as the payment method used and the payment amount. Payment
+method specific information, such as the status of the payment, may also be
+included. The presence and meaning of this extra information is dependent on
+the payment method. The payment information may be used by the <a>payee</a> or
+their associated <a>payment service provider</a> to, for example, finalize a
+payment or display information to the <a>payer</a>.
+        </dd>
+      </dl>
+
+      <pre class="example highlight"
+        title="An example of a payment response">
+{
+  "type": "PaymentResponse",
+  "description": "Payment to ExampleMerch for widgets",
+  "payment": {
+    "paymentMethod": "VisaLegacy",
+    "paymentAmount": {
+      "amount": "4.35",
+      "currency": "USD"
+    },
+    ... // payment method specific response details here
+  }
+};
+      </pre>
+    </section>
+</section>
+
+  <section>
+    <h2>Expressing Messages as WebIDL</h2>
+
+    <p>
+The Web Payments messages described in this specification are intended to be
+used in browser-based programming environments. The conformance language for
+browser-based objects is WebIDL. The table below cross-references the messages
+in this specification to their WebIDL definitions in other specifications.
+    </p>
+
+    <table class="simple">
+      <thead>
+        <th>Message</th>
+        <th>WebIDL Definition</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a>PaymentRequest</a></td>
+          <td>[[PAYMENT-REQUEST-API]] <a href="https://w3c.github.io/browser-payment-api/specs/paymentrequest.html#paymentrequest-interface">Section 4: Payment Response</a></td>
+        </tr>
+        <tr>
+          <td><a>PaymentResponse</a></td>
+          <td>[[PAYMENT-REQUEST-API]] <a href="https://w3c.github.io/browser-payment-api/specs/paymentrequest.html#paymentresponse-interface">Section 11: Payment Response</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+  </section>
+
+  <section>
+    <h2>Expressing Messages as JSON</h2>
+
+    <p>
+The Web Payments messages described in this specification are intended to be
+used in programming environments that support JSON. The conformance language
+for JSON objects is JSON Schema. The table below cross-references the messages
+in this specification to their JSON Schema definitions.
+    </p>
+
+    <table class="simple">
+      <thead>
+        <th>Message</th>
+        <th>JSON Schema</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a>PaymentRequest</a></td>
+          <td><a href="schemas/PaymentRequest.json">PaymentRequest.json</a></td>
+        </tr>
+        <tr>
+          <td><a>PaymentResponse</a></td>
+          <td><a href="schemas/PaymentResponse.json">PaymentResponse.json</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+  </section>
+
+  <section>
+    <h2>Expressing Messages as JSON-LD</h2>
+
+    <p class="issue">
+One proposal for providing message extensibility is to allow messages to
+be interpreted as JSON-LD with a specific context, such as
+<code>https://example.org/contexts/web-payments/v1</code>. Doing this would
+not only solve message versioning, but it would also enable
+decentralized extensibility for all payment messages while ensuring that
+there are no clashes in terminology between industry verticals.
+    </p>
+
+    <p>
+The Web Payments messages described in this specification are intended to be
+used in programming environments that support JSON-LD. The conformance language
+for JSON-LD objects is a JSON-LD Frame coupled with JSON Schema. The table
+below cross-references the messages in this specification to their
+JSON-LD Frames and JSON Schema definitions.
+    </p>
+
+
+    <table class="simple">
+      <thead>
+        <th>Message</th>
+        <th>JSON-LD Frame</th>
+        <th>JSON Schema</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a>PaymentRequest</a></td>
+          <td><a href="frames/PaymentRequest-frame.jsonld">PaymentRequest-frame.jsonld</a></td>
+          <td><a href="schemas/PaymentRequest.json">PaymentRequest.json</a></td>
+        </tr>
+        <tr>
+          <td><a>PaymentResponse</a></td>
+          <td><a href="frames/PaymentResponse-frame.jsonld">PaymentResponse-frame.jsonld</a></td>
+          <td><a href="schemas/PaymentResponse.json">PaymentResponse.json</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+  </section>
+
+  <section>
+    <h2>Security Considerations</h2>
+
+    <section>
+      <h3>Message Integrity</h3>
+      <p class="issue">
+There are a variety of ways that message integrity can be protected. Which
+set of methods will this specification employ.
+      </p>
+    </section>
+
+    <section>
+      <h3>Message Replay</h3>
+      <p class="issue">
+There are a variety of ways that message replay can be protected against. Which
+set of methods will this specification employ.
+      </p>
+    </section>
+  </section>
+
+</section>
+
+<section class="appendix informative">
+  <h2>Acknowledgements</h2>
+
+  <p>
+The editor would like to thank the Web Payments Community Group and the
+Web Payments Working Group.
+  </p>
+
+  <p>
+Thanks to the following individuals, in order of their first name, for
+their input on the specification: ...
+  </p>
+
+</section>
+
+</body>
+</html>

--- a/proposals/core-messages/schemas/PaymentRequest.json
+++ b/proposals/core-messages/schemas/PaymentRequest.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://www.w3.org/Payments/WG/PaymentRequest",
+  "type": "object",
+  "properties": {
+    "type": {
+      "id": "https://www.w3.org/Payments/WG/PaymentRequest/type",
+      "type": "string"
+    },
+    "description": {
+      "id": "https://www.w3.org/Payments/WG/PaymentRequest/description",
+      "type": "string"
+    },
+    "acceptablePayment": {
+      "id": "https://www.w3.org/Payments/WG/PaymentRequest/acceptablePayment",
+      "type": "object",
+      "properties": {
+        "paymentMethod": {
+          "id": "https://www.w3.org/Payments/WG/PaymentRequest/acceptablePayment/paymentMethod",
+          "type": "string"
+        },
+        "paymentAmount": {
+          "id": "https://www.w3.org/Payments/WG/PaymentRequest/acceptablePayment/paymentAmount",
+          "type": "object",
+          "properties": {
+            "amount": {
+              "id": "https://www.w3.org/Payments/WG/PaymentRequest/acceptablePayment/paymentAmount/amount",
+              "type": "string",
+              "pattern": "^-?[0-9]+(\.[0-9]+)?$"
+            },
+            "currency": {
+              "id": "https://www.w3.org/Payments/WG/PaymentRequest/acceptablePayment/paymentAmount/currency",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [ "acceptablePayment" ]
+}

--- a/proposals/core-messages/schemas/PaymentResponse.json
+++ b/proposals/core-messages/schemas/PaymentResponse.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://www.w3.org/Payments/WG/PaymentResponse",
+  "type": "object",
+  "properties": {
+    "type": {
+      "id": "https://www.w3.org/Payments/WG/PaymentResponse/type",
+      "type": "string"
+    },
+    "description": {
+      "id": "https://www.w3.org/Payments/WG/PaymentResponse/description",
+      "type": "string"
+    },
+    "payment": {
+      "id": "https://www.w3.org/Payments/WG/PaymentResponse/payment",
+      "type": "object",
+      "properties": {
+        "paymentMethod": {
+          "id": "https://www.w3.org/Payments/WG/PaymentResponse/payment/paymentMethod",
+          "type": "string"
+        },
+        "paymentAmount": {
+          "id": "https://www.w3.org/Payments/WG/PaymentResponse/payment/paymentAmount",
+          "type": "object",
+          "properties": {
+            "amount": {
+              "id": "https://www.w3.org/Payments/WG/PaymentResponse/payment/paymentAmount/amount",
+              "type": "string",
+              "pattern": "^-?[0-9]+(\.[0-9]+)?$"
+            },
+            "currency": {
+              "id": "https://www.w3.org/Payments/WG/PaymentResponse/payment/paymentAmount/currency",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "payment"
+  ]
+}

--- a/proposals/core-messages/spec.css
+++ b/proposals/core-messages/spec.css
@@ -1,0 +1,3 @@
+ol.algorithm { counter-reset:numsection; list-style-type: none; }
+ol.algorithm li { margin: 0.5em 0; }
+ol.algorithm li:before { font-weight: bold; counter-increment: numsection; content: counters(numsection, ".") ") "; }

--- a/proposals/core-messages/utils.js
+++ b/proposals/core-messages/utils.js
@@ -1,0 +1,49 @@
+// We should be able to remove terms that are not actually
+// referenced from the common definitions
+var termNames = [] ;
+
+function restrictReferences(utils, content) {
+    var base = document.createElement("div");
+    base.innerHTML = content;
+
+    // strategy: Traverse the content finding all of the terms defined
+    $.each(base.querySelectorAll("dfn"), function(i, item) {
+        var $t = $(item) ;
+        var titles = $t.getDfnTitles();
+        var n = $t.makeID("dfn", titles[0]);
+        if (n) {
+            termNames[n] = $t.parent() ;
+        }
+    });
+
+    // add a handler to come in after all the definitions are resolved
+
+    respecEvents.sub('end', function(message) {
+        if (message == 'core/link-to-dfn') {
+            // all definitions are linked
+            $("a.internalDFN").each(function () {
+                var $item = $(this) ;
+                var r = $item.attr('href').replace(/^#/,"") ;
+                if (termNames[r]) {
+                    delete termNames[r] ;
+                }
+            });
+    // delete any terms that were not referenced.
+            Object.keys(termNames).forEach(function(term) {
+                var $p = $("#"+term) ;
+                if ($p) {
+                    var tList = $p.getDfnTitles();
+                    $p.parent().next().remove();
+                    $p.remove() ;
+                    tList.forEach(function( item ) {
+                        if (respecConfig.definitionMap[item]) {
+                            delete respecConfig.definitionMap[item];
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    return (base.innerHTML);
+}


### PR DESCRIPTION
This is a PR to merge in the Web Payments Core Messages specification into the WPWG's proposals directory. You can see a human-readable version of this specification here:

http://manu.sporny.org/tmp/wpwg/webpayments/proposals/core-messages/

The specification:
1. Outlines a generalized data model for Web Payments messages,
2. Describes the core Web Payments messages using the data model, and
3. Specifies message conformance and data validation criteria in using WebIDL (browsers), JSON Schema (non-browser JSON environments), and JSON-LD (non-browser JSON-LD environments).

The intent is that these messages are used by the HTTP API and an attempt is made to try and align these messages with the Browser API as well.
