### PR TITLE
Add mention of private browsing as insufficient

### DIFF
--- a/proposals/privacy-threat-model.html
+++ b/proposals/privacy-threat-model.html
@@ -10,7 +10,7 @@
     <script src="utils.js" class="remove"></script>
     <script class='remove'>
       var respecConfig = {
-          github:    "https://github.com/w3c/webpayments/",
+	  github: "w3c/webpayments",
           status: "MEMBER-SUB",
           maxTocLevel: 3,
           editors: [{

--- a/proposals/privacy-threat-model.html
+++ b/proposals/privacy-threat-model.html
@@ -10,6 +10,7 @@
     <script src="utils.js" class="remove"></script>
     <script class='remove'>
       var respecConfig = {
+          github:    "https://github.com/w3c/webpayments/",
           status: "MEMBER-SUB",
           maxTocLevel: 3,
           editors: [{

--- a/proposals/privacy-threat-model.html
+++ b/proposals/privacy-threat-model.html
@@ -149,6 +149,10 @@
         cards (e.g., business and personal) belong to the same individual, the
         user should make use of two profiles.
         </li>
+        <li>Although "private browsing mode" may help mitigate some of the
+        threats described here, we do not consider it a sufficient mitigation
+        strategy.
+        </li>
         <li>Most browsers are moving in the direction of double-keyed
         partitioning, whatever the storage mechanism.
         </li>


### PR DESCRIPTION
Private browsing mode may help to mitigate some of the threats described in the document.
I added an assumption that although it may be useful, it is not sufficient. That is, I would not expect us to tell users that the should just use private browsing mode to address these issues.

Also: added repo URL to the metadata while I was in there.